### PR TITLE
feat(UI): Improve error/alert handling and photo info display

### DIFF
--- a/ImageQuest.xcodeproj/project.pbxproj
+++ b/ImageQuest.xcodeproj/project.pbxproj
@@ -53,12 +53,15 @@
 		E46D2A2D2BBDB96E00D44C16 /* PhotosEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46D2A2C2BBDB96E00D44C16 /* PhotosEndpointTests.swift */; };
 		E46D2A2F2BBDBADA00D44C16 /* SearchEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E46D2A2E2BBDBADA00D44C16 /* SearchEndpointTests.swift */; };
 		E4A1A35A2BBE058500726F1E /* Config.json in Resources */ = {isa = PBXBuildFile; fileRef = E4A1A3592BBE058500726F1E /* Config.json */; };
+		E4A6E4C72BFB9FB5007B1A66 /* AppAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A6E4C62BFB9FB5007B1A66 /* AppAlert.swift */; };
+		E4A6E4CB2BFBA6AD007B1A66 /* NetworkAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4A6E4CA2BFBA6AD007B1A66 /* NetworkAlert.swift */; };
 		E4ABDD862BBD5623004B8EF1 /* ImageQuestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4ABDD852BBD5623004B8EF1 /* ImageQuestApp.swift */; };
 		E4ABDD882BBD5623004B8EF1 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4ABDD872BBD5623004B8EF1 /* ContentView.swift */; };
 		E4ABDD8A2BBD5624004B8EF1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4ABDD892BBD5624004B8EF1 /* Assets.xcassets */; };
 		E4ABDD8D2BBD5624004B8EF1 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E4ABDD8C2BBD5624004B8EF1 /* Preview Assets.xcassets */; };
 		E4ABDDA12BBD5625004B8EF1 /* ImageQuestUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4ABDDA02BBD5625004B8EF1 /* ImageQuestUITests.swift */; };
 		E4ABDDA32BBD5625004B8EF1 /* ImageQuestUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4ABDDA22BBD5625004B8EF1 /* ImageQuestUITestsLaunchTests.swift */; };
+		E4B05C032BD129770077709F /* View+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B05C022BD129770077709F /* View+Ext.swift */; };
 		E4DD9F792BC2B9FF0095B2DB /* ScreenSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DD9F782BC2B9FF0095B2DB /* ScreenSize.swift */; };
 		E4DD9F7B2BC2DC750095B2DB /* ImageGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DD9F7A2BC2DC750095B2DB /* ImageGesture.swift */; };
 		E4F4E3182BBEA473009CD582 /* OrderBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F4E3172BBEA473009CD582 /* OrderBy.swift */; };
@@ -144,6 +147,8 @@
 		E46D2A2C2BBDB96E00D44C16 /* PhotosEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotosEndpointTests.swift; sourceTree = "<group>"; };
 		E46D2A2E2BBDBADA00D44C16 /* SearchEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEndpointTests.swift; sourceTree = "<group>"; };
 		E4A1A3592BBE058500726F1E /* Config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Config.json; sourceTree = "<group>"; };
+		E4A6E4C62BFB9FB5007B1A66 /* AppAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAlert.swift; sourceTree = "<group>"; };
+		E4A6E4CA2BFBA6AD007B1A66 /* NetworkAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkAlert.swift; sourceTree = "<group>"; };
 		E4ABDD822BBD5623004B8EF1 /* ImageQuest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ImageQuest.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4ABDD852BBD5623004B8EF1 /* ImageQuestApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageQuestApp.swift; sourceTree = "<group>"; };
 		E4ABDD872BBD5623004B8EF1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -153,6 +158,7 @@
 		E4ABDD9C2BBD5625004B8EF1 /* ImageQuestUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ImageQuestUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4ABDDA02BBD5625004B8EF1 /* ImageQuestUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageQuestUITests.swift; sourceTree = "<group>"; };
 		E4ABDDA22BBD5625004B8EF1 /* ImageQuestUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageQuestUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		E4B05C022BD129770077709F /* View+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Ext.swift"; sourceTree = "<group>"; };
 		E4DD9F782BC2B9FF0095B2DB /* ScreenSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenSize.swift; sourceTree = "<group>"; };
 		E4DD9F7A2BC2DC750095B2DB /* ImageGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageGesture.swift; sourceTree = "<group>"; };
 		E4F4E3172BBEA473009CD582 /* OrderBy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderBy.swift; sourceTree = "<group>"; };
@@ -233,6 +239,7 @@
 			isa = PBXGroup;
 			children = (
 				E411D0642BC18406005EDD15 /* Date+Ext.swift */,
+				E4B05C022BD129770077709F /* View+Ext.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -391,6 +398,15 @@
 				E46D2A2E2BBDBADA00D44C16 /* SearchEndpointTests.swift */,
 			);
 			path = Unsplash;
+			sourceTree = "<group>";
+		};
+		E4A6E4C52BFB9FA9007B1A66 /* Alerts */ = {
+			isa = PBXGroup;
+			children = (
+				E4A6E4C62BFB9FB5007B1A66 /* AppAlert.swift */,
+				E4A6E4CA2BFBA6AD007B1A66 /* NetworkAlert.swift */,
+			);
+			path = Alerts;
 			sourceTree = "<group>";
 		};
 		E4ABDD792BBD5623004B8EF1 = {
@@ -601,6 +617,7 @@
 		E4F4E34C2BBF2C73009CD582 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				E4A6E4C52BFB9FA9007B1A66 /* Alerts */,
 				E4F4E34D2BBF2E3B009CD582 /* Navigation */,
 				E4F4E3562BBF4BF8009CD582 /* Screens */,
 				E411D0602BC175C7005EDD15 /* Subviews */,
@@ -811,6 +828,7 @@
 				E46D2A142BBD673100D44C16 /* SearchEndpoint.swift in Sources */,
 				E42A2D882BC14468002EAED7 /* PhotoShareLink.swift in Sources */,
 				E4F4E3322BBECEDE009CD582 /* PhotoResponseDTO.swift in Sources */,
+				E4A6E4C72BFB9FB5007B1A66 /* AppAlert.swift in Sources */,
 				E4F4E3592BBFE726009CD582 /* DiscoverPhotosView.swift in Sources */,
 				E411D0652BC18406005EDD15 /* Date+Ext.swift in Sources */,
 				E46D2A102BBD64F400D44C16 /* PhotosEndpoint.swift in Sources */,
@@ -828,6 +846,7 @@
 				E46D2A122BBD65E900D44C16 /* QueryItems.swift in Sources */,
 				E4F4E3272BBEC92D009CD582 /* LatestPhotosUseCase.swift in Sources */,
 				E4F4E32E2BBECE3A009CD582 /* PhotoRepository.swift in Sources */,
+				E4A6E4CB2BFBA6AD007B1A66 /* NetworkAlert.swift in Sources */,
 				E46D2A092BBD628200D44C16 /* EndpointProtocol.swift in Sources */,
 				E411D05F2BC16208005EDD15 /* PhotoDetailViewModel.swift in Sources */,
 				E42A2D862BC143E9002EAED7 /* BackButton.swift in Sources */,
@@ -841,6 +860,7 @@
 				E4F4E3232BBEC409009CD582 /* Photographer.swift in Sources */,
 				E4F4E3212BBEB70C009CD582 /* Photo.swift in Sources */,
 				E411D05D2BC161B1005EDD15 /* PhotoInfoSheet.swift in Sources */,
+				E4B05C032BD129770077709F /* View+Ext.swift in Sources */,
 				E4F4E3532BBF3073009CD582 /* DiscoverDestination.swift in Sources */,
 				E46D2A1B2BBD6C3C00D44C16 /* JSONDecoder+Ext.swift in Sources */,
 				E46D2A032BBD61C700D44C16 /* Error+Connection.swift in Sources */,

--- a/ImageQuest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ImageQuest.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/unsplash/swiftui-lazycollectionview.git",
       "state" : {
-        "revision" : "e3b9f5c261ca2669269ba2107d3ecdba5146d7e0",
-        "version" : "1.1.0"
+        "revision" : "c705ce063a5d7478b6b5ac282be6daa6f419eb1c",
+        "version" : "1.2.0"
       }
     }
   ],

--- a/ImageQuest/Infrastructure/Network/EndpointProtocol.swift
+++ b/ImageQuest/Infrastructure/Network/EndpointProtocol.swift
@@ -28,7 +28,9 @@ extension EndpointProtocol {
         let baseUrl = baseURL.hasSuffix("/") ? baseURL : baseURL.appending("/")
         let endpoint = baseUrl.appending(path)
         
-        var urlComponents = URLComponents(string: endpoint)!
+        guard var urlComponents = URLComponents(string: endpoint) else {
+            fatalError("Invalid URL")
+        }
         
         var urlQueryItems = [URLQueryItem]()
         for queryParameter in queryParameters {
@@ -36,9 +38,13 @@ extension EndpointProtocol {
         }
         urlComponents.queryItems = urlQueryItems.isEmpty ? nil : urlQueryItems
         
-        return urlComponents.url!
+        guard let url = urlComponents.url else {
+            fatalError("Invalid URL components")
+        }
+        
+        return url
     }
-
+    
     func urlRequest() async throws -> URLRequest {
         let url = url()
         var urlRequest = URLRequest(url: url)

--- a/ImageQuest/Infrastructure/Network/NetworkError.swift
+++ b/ImageQuest/Infrastructure/Network/NetworkError.swift
@@ -36,39 +36,3 @@ enum NetworkError: Error {
     /// Unknown error.
     case unknown
 }
-
-extension NetworkError: LocalizedError {
-    var errorDescription: String? {
-        switch self {
-        case .network(let error):
-            if error.isOtherConnectionError {
-                return "Check your network or switch to a faster connection, then try again."
-            }
-            return error.localizedDescription
-            
-        case .badRequest:
-            return "The request was unacceptable, often due to missing a required parameter"
-            
-        case .unauthorised:
-            return "Invalid Access Token"
-                        
-        case .forbidden:
-            return "Missing permissions to perform request"
-            
-        case .notFound:
-            return "The requested resource doesn’t exist"
-            
-        case .tooManyRequests:
-            return "Too many requests"
-            
-        case .internalServerError, .notImplemented, .badGateway, .serviceUnavailable, .gatewayTimeout:
-            return "Something went wrong on our end"
-            
-        case .decode(let error):
-            return error.localizedDescription
-            
-        case .unknown:
-            return "Unknown error"
-        }
-    }
-}

--- a/ImageQuest/Presentation/Alerts/AppAlert.swift
+++ b/ImageQuest/Presentation/Alerts/AppAlert.swift
@@ -1,0 +1,14 @@
+//
+//  AppAlert.swift
+//  ImageQuest
+//
+//  Created by Sylvain Druaux on 20/05/2024.
+//
+
+import SwiftUI
+
+protocol AppAlert {
+    var title: String { get }
+    var message: String? { get }
+    func getButtonsForAlert(action: (() -> Void)?) -> AnyView
+}

--- a/ImageQuest/Presentation/Alerts/NetworkAlert.swift
+++ b/ImageQuest/Presentation/Alerts/NetworkAlert.swift
@@ -1,0 +1,87 @@
+//
+//  NetworkAlert.swift
+//  ImageQuest
+//
+//  Created by Sylvain Druaux on 20/05/2024.
+//
+
+import SwiftUI
+
+extension NetworkError: AppAlert {
+    var title: String {
+        switch self {
+        case .network(let error):
+            if error.isOtherConnectionError {
+                return "Poor connection"
+            }
+            return "Network error"
+            
+        case .badRequest:
+            return "Bad request"
+            
+        case .unauthorised, .forbidden:
+            return "Unauthorized access"
+            
+        case .notFound:
+            return "Not found"
+            
+        case .tooManyRequests:
+            return "Too many requests"
+            
+        case .internalServerError, .notImplemented, .badGateway, .serviceUnavailable, .gatewayTimeout:
+            return "Server error"
+            
+        case .decode:
+            return "Data error"
+            
+        case .unknown:
+            return "Unknown error"
+        }
+    }
+    
+    var message: String? {
+        switch self {
+        case .network(let error):
+            if error.isOtherConnectionError {
+                return "Check your network or switch to a faster connection, then try again."
+            }
+            return "Something went wrong on our end. Please try again later."
+            
+        case .badRequest:
+            return "The request was invalid, usually due to a missing required parameter."
+            
+        case .unauthorised, .forbidden:
+            return "Missing permissions to perform request."
+            
+        case .notFound:
+            return "The requested resource doesn’t exist."
+            
+        case .tooManyRequests:
+            return "Too many requests. Please try again later."
+            
+        case .internalServerError, .notImplemented, .badGateway, .serviceUnavailable, .gatewayTimeout:
+            return "Something went wrong on our end. Please try again later."
+            
+        case .decode:
+            return "Could not retrieve data. Please try again later."
+            
+        case .unknown:
+            return "Unknown error."
+        }
+    }
+    
+    func getButtonsForAlert(action: (() -> Void)?) -> AnyView {
+        AnyView(getButtons(action: action))
+    }
+    
+    @ViewBuilder private func getButtons(action: (() -> Void)?) -> some View {
+        switch self {
+        case .network:
+            Button("Try again") {
+                action?()
+            }
+        default:
+            Button("OK", role: .cancel) {}
+        }
+    }
+}

--- a/ImageQuest/Presentation/Extensions/View+Ext.swift
+++ b/ImageQuest/Presentation/Extensions/View+Ext.swift
@@ -1,0 +1,23 @@
+//
+//  View+Ext.swift
+//  ImageQuest
+//
+//  Created by Sylvain Druaux on 18/04/2024.
+//
+
+import SwiftUI
+
+extension View {
+    func errorAlert<T: AppAlert>(alert: Binding<T?>, action: (() -> Void)? = nil) -> some View {
+        self
+            .alert(alert.wrappedValue?.title ?? "Error", isPresented: .constant(alert.wrappedValue != nil), actions: {
+                alert.wrappedValue?.getButtonsForAlert {
+                    action?()
+                }
+            }, message: {
+                if let message = alert.wrappedValue?.message {
+                    Text(message)
+                }
+            })
+    }
+}

--- a/ImageQuest/Presentation/Screens/DiscoverPhotosView/DiscoverPhotosView.swift
+++ b/ImageQuest/Presentation/Screens/DiscoverPhotosView/DiscoverPhotosView.swift
@@ -66,8 +66,8 @@ struct DiscoverPhotosView: View {
         .overlay {
             if !viewModel.searchText.isEmpty { PhotosSearchResult(viewModel: viewModel) }
         }
-        .alert(viewModel.error ?? "", isPresented: $viewModel.hasError) {
-            Button("OK", role: .cancel) {}
+        .errorAlert(alert: $viewModel.error) {
+            Task { await viewModel.loadLatestPhotos() }
         }
     }
 }

--- a/ImageQuest/Presentation/Screens/DiscoverPhotosView/DiscoverPhotosViewModel.swift
+++ b/ImageQuest/Presentation/Screens/DiscoverPhotosView/DiscoverPhotosViewModel.swift
@@ -14,8 +14,7 @@ final class DiscoverPhotosViewModel: ObservableObject {
     @Published private(set) var photos: [Photo] = []
     @Published private(set) var latestPhotosLayout = ColumnLayout<Photo>(properties: FixedColumnLayoutProperties.twoColumns)
     @Published private(set) var photosLayout = ColumnLayout<Photo>(properties: FixedColumnLayoutProperties.twoColumns)
-    @Published private(set) var error: String?
-    @Published var hasError = false
+    @Published var error: NetworkError?
     
     private var photosTotalPages: Int = 1
     private var photosPageNumber: Int = 1
@@ -40,8 +39,7 @@ final class DiscoverPhotosViewModel: ObservableObject {
         do {
             latestPhotos = try await latestPhotosUseCase.execute(page: 1, perPage: 30)
         } catch {
-            self.error = (error as? NetworkError)?.errorDescription ?? error.localizedDescription
-            hasError = true
+            self.error = error as? NetworkError
         }
     }
     
@@ -54,8 +52,7 @@ final class DiscoverPhotosViewModel: ObservableObject {
             photos += photosPage.photos
             photosPageNumber += 1
         } catch {
-            self.error = (error as? NetworkError)?.errorDescription ?? error.localizedDescription
-            hasError = true
+            self.error = error as? NetworkError
         }
     }
 }

--- a/ImageQuest/Presentation/Screens/PhotoDetailView/PhotoDetailView.swift
+++ b/ImageQuest/Presentation/Screens/PhotoDetailView/PhotoDetailView.swift
@@ -57,15 +57,10 @@ struct PhotoDetailView: View {
         .toolbarBackground(.hidden, for: .navigationBar)
         .task { await viewModel.loadDetailedPhoto(photo.id) }
         .sheet(isPresented: $viewModel.isShowingPhotoInfoSheet) {
-            NavigationStack {
-                PhotoInfoSheet(photo: viewModel.detailedPhoto ?? photo, cameraPosition: viewModel.cameraPosition)
-                    .navigationBarItems(
-                        leading: Button("Close") { viewModel.isShowingPhotoInfoSheet = false }
-                    )
-            }
+            PhotoInfoSheet(photo: viewModel.detailedPhoto ?? photo, cameraPosition: viewModel.cameraPosition)
         }
-        .alert(viewModel.error ?? "", isPresented: $viewModel.hasError) {
-            Button("OK", role: .cancel) {}
+        .errorAlert(alert: $viewModel.error) {
+            Task { await viewModel.loadDetailedPhoto(photo.id) }
         }
     }
 }

--- a/ImageQuest/Presentation/Screens/PhotoDetailView/PhotoDetailViewModel.swift
+++ b/ImageQuest/Presentation/Screens/PhotoDetailView/PhotoDetailViewModel.swift
@@ -12,8 +12,7 @@ import _MapKit_SwiftUI
 final class PhotoDetailViewModel: ObservableObject {
     @Published private(set) var detailedPhoto: Photo?
     @Published private(set) var cameraPosition: MapCameraPosition?
-    @Published private(set) var error: String?
-    @Published var hasError = false
+    @Published var error: NetworkError?
     @Published var isShowingPhotoInfoSheet = false
     
     private let detailedPhotoUseCase: DetailedPhotoUseCaseProtocol
@@ -36,8 +35,7 @@ final class PhotoDetailViewModel: ObservableObject {
                 ))
             }
         } catch {
-            self.error = (error as? NetworkError)?.errorDescription ?? error.localizedDescription
-            hasError = true
+            self.error = error as? NetworkError
         }
     }
 }

--- a/ImageQuest/Presentation/Screens/PhotoDetailView/PhotoInfoSheet.swift
+++ b/ImageQuest/Presentation/Screens/PhotoDetailView/PhotoInfoSheet.swift
@@ -9,11 +9,23 @@ import SwiftUI
 import MapKit
 
 struct PhotoInfoSheet: View {
+    @Environment(\.dismiss) private var dismiss
     let photo: Photo
     let cameraPosition: MapCameraPosition?
     
     var body: some View {
         VStack(alignment: .leading) {
+            HStack {
+                Text("Info")
+                    .font(.headline)
+            }
+            .frame(maxWidth: .infinity)
+            .overlay(alignment: .leading) {
+                Button("Close") { dismiss() }
+            }
+            .padding(.top)
+            .padding(.bottom, 48)
+            
             if let description = photo.description {
                 Text(description)
                     .lineLimit(4)
@@ -22,17 +34,17 @@ struct PhotoInfoSheet: View {
             }
             
             if let cameraPosition,
-                let position = photo.location?.position,
-                let latitude = position.latitude,
-                let longitude = position.longitude {
-                    Map(initialPosition: cameraPosition) {
-                        Marker("", coordinate: CLLocationCoordinate2D(
-                            latitude: latitude,
-                            longitude: longitude
-                        ))
-                    }
-                    .frame(height: 150)
-                    .padding(.bottom)
+               let position = photo.location?.position,
+               let latitude = position.latitude,
+               let longitude = position.longitude {
+                Map(initialPosition: cameraPosition) {
+                    Marker("", coordinate: CLLocationCoordinate2D(
+                        latitude: latitude,
+                        longitude: longitude
+                    ))
+                }
+                .frame(height: 150)
+                .padding(.bottom)
             }
             
             if let locationName = photo.location?.name {
@@ -52,15 +64,11 @@ struct PhotoInfoSheet: View {
             
             Spacer()
         }
-        .navigationTitle("Info")
-        .navigationBarTitleDisplayMode(.inline)
-        .padding(.top, 32)
         .padding(.horizontal)
     }
 }
 
-#if DEBUG
-struct PhotoInfoSheetContainer: View {
+#Preview {
     let cameraPosition = MapCameraPosition.region(.init(
         center: CLLocationCoordinate2D(
             latitude: Photo.firstPhoto.location?.position?.latitude ?? 0.0,
@@ -69,15 +77,6 @@ struct PhotoInfoSheetContainer: View {
         latitudinalMeters: 1100, longitudinalMeters: 1100
     ))
     
-    var body: some View {
-        PhotoInfoSheet(photo: .firstPhoto, cameraPosition: cameraPosition)
-    }
-}
-#endif
-
-#Preview {
-    NavigationStack {
-        PhotoInfoSheetContainer()
-    }
-    .preferredColorScheme(.dark)
+    return PhotoInfoSheet(photo: .firstPhoto, cameraPosition: cameraPosition)
+        .preferredColorScheme(.dark)
 }

--- a/ImageQuest/Presentation/Styles/ColumnLayout/ColumnLayout.swift
+++ b/ImageQuest/Presentation/Styles/ColumnLayout/ColumnLayout.swift
@@ -5,8 +5,6 @@
 //  Created by Sylvain Druaux on 07/04/2024.
 //
 
-/// Big thanks to Olivier Collet for this awesome open-source photo layout
-
 import SwiftUI
 import LazyCollectionView
 
@@ -189,5 +187,4 @@ class ColumnLayout<Item>: ObservableObject, LazyCollectionLayout where Item: Col
         let height = size.height * columnWidth / size.width
         return CGSize(width: floor(columnWidth), height: floor(height))
     }
-
 }

--- a/ImageQuest/Presentation/Styles/ColumnLayout/ColumnLayoutProperties.swift
+++ b/ImageQuest/Presentation/Styles/ColumnLayout/ColumnLayoutProperties.swift
@@ -5,8 +5,6 @@
 //  Created by Sylvain Druaux on 07/04/2024.
 //
 
-/// Big thanks to Olivier Collet for this awesome open-source photo layout
-
 import SwiftUI
 
 protocol ColumnLayoutProperties {

--- a/ImageQuestTests/Infrastructure/Network/Mocks/URLProtocolMock.swift
+++ b/ImageQuestTests/Infrastructure/Network/Mocks/URLProtocolMock.swift
@@ -11,14 +11,12 @@ final class URLProtocolMock: URLProtocol {
     static var data: Data?
     static var failError: Error?
     static var responseStatusCode: Int = 200
-    private(set) static var lastRequest: URLRequest?
     
     override class func canInit(with _: URLRequest) -> Bool {
         true
     }
     
     override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-        lastRequest = request
         return request
     }
     
@@ -52,6 +50,5 @@ final class URLProtocolMock: URLProtocol {
         data = nil
         failError = nil
         responseStatusCode = 200
-        lastRequest = nil
     }
 }

--- a/ImageQuestTests/Infrastructure/Network/NetworkErrorTests.swift
+++ b/ImageQuestTests/Infrastructure/Network/NetworkErrorTests.swift
@@ -17,7 +17,7 @@ class NetworkErrorTests: XCTestCase {
         switch networkError {
         case .network(let error):
             XCTAssertTrue(error.isOtherConnectionError)
-            XCTAssertNotNil(networkError.errorDescription)
+            XCTAssertNotNil(networkError.localizedDescription)
             
         default:
             XCTFail("Error does not match")
@@ -33,7 +33,7 @@ class NetworkErrorTests: XCTestCase {
         switch networkError {
         case .badRequest(let message):
             XCTAssertEqual(message, expectedMessage)
-            XCTAssertNotNil(networkError.errorDescription)
+            XCTAssertNotNil(networkError.localizedDescription)
             
         default:
             XCTFail("Error does not match")
@@ -49,7 +49,7 @@ class NetworkErrorTests: XCTestCase {
         switch networkError {
         case .unauthorised(let message):
             XCTAssertEqual(message, expectedMessage)
-            XCTAssertNotNil(networkError.errorDescription)
+            XCTAssertNotNil(networkError.localizedDescription)
             
         default:
             XCTFail("Error does not match")
@@ -65,7 +65,7 @@ class NetworkErrorTests: XCTestCase {
         switch networkError {
         case .forbidden(let message):
             XCTAssertEqual(message, expectedMessage)
-            XCTAssertNotNil(networkError.errorDescription)
+            XCTAssertNotNil(networkError.localizedDescription)
             
         default:
             XCTFail("Error does not match")
@@ -81,7 +81,7 @@ class NetworkErrorTests: XCTestCase {
         switch networkError {
         case .notFound(let message):
             XCTAssertEqual(message, expectedMessage)
-            XCTAssertNotNil(networkError.errorDescription)
+            XCTAssertNotNil(networkError.localizedDescription)
             
         default:
             XCTFail("Error does not match")
@@ -97,7 +97,7 @@ class NetworkErrorTests: XCTestCase {
         switch networkError {
         case .tooManyRequests(let message):
             XCTAssertEqual(message, expectedMessage)
-            XCTAssertNotNil(networkError.errorDescription)
+            XCTAssertNotNil(networkError.localizedDescription)
             
         default:
             XCTFail("Error does not match")
@@ -113,7 +113,7 @@ class NetworkErrorTests: XCTestCase {
         switch networkError {
         case .internalServerError(let message):
             XCTAssertEqual(message, expectedMessage)
-            XCTAssertNotNil(networkError.errorDescription)
+            XCTAssertNotNil(networkError.localizedDescription)
             
         default:
             XCTFail("Error does not match")
@@ -129,7 +129,7 @@ class NetworkErrorTests: XCTestCase {
         switch networkError {
         case .notImplemented(let message):
             XCTAssertEqual(message, expectedMessage)
-            XCTAssertNotNil(networkError.errorDescription)
+            XCTAssertNotNil(networkError.localizedDescription)
             
         default:
             XCTFail("Error does not match")
@@ -145,7 +145,7 @@ class NetworkErrorTests: XCTestCase {
         switch networkError {
         case .badGateway(let message):
             XCTAssertEqual(message, expectedMessage)
-            XCTAssertNotNil(networkError.errorDescription)
+            XCTAssertNotNil(networkError.localizedDescription)
             
         default:
             XCTFail("Error does not match")
@@ -161,7 +161,7 @@ class NetworkErrorTests: XCTestCase {
         switch networkError {
         case .serviceUnavailable(let message):
             XCTAssertEqual(message, expectedMessage)
-            XCTAssertNotNil(networkError.errorDescription)
+            XCTAssertNotNil(networkError.localizedDescription)
             
         default:
             XCTFail("Error does not match")
@@ -177,7 +177,7 @@ class NetworkErrorTests: XCTestCase {
         switch networkError {
         case .gatewayTimeout(let message):
             XCTAssertEqual(message, expectedMessage)
-            XCTAssertNotNil(networkError.errorDescription)
+            XCTAssertNotNil(networkError.localizedDescription)
             
         default:
             XCTFail("Error does not match")
@@ -191,7 +191,7 @@ class NetworkErrorTests: XCTestCase {
         
         switch networkError {
         case .decode:
-            XCTAssertNotNil(networkError.errorDescription)
+            XCTAssertNotNil(networkError.localizedDescription)
             
         default:
             XCTFail("Error does not match")
@@ -206,7 +206,7 @@ class NetworkErrorTests: XCTestCase {
         switch networkError {
         case .unknown:
             XCTAssertTrue(true)
-            XCTAssertNotNil(networkError.errorDescription)
+            XCTAssertNotNil(networkError.localizedDescription)
             
         default:
             XCTFail("Error does not match")

--- a/ImageQuestTests/Presentation/DiscoverPhotosViewModelTests.swift
+++ b/ImageQuestTests/Presentation/DiscoverPhotosViewModelTests.swift
@@ -69,7 +69,7 @@ class DiscoverPhotosViewModelTests: XCTestCase {
         await sut.loadLatestPhotos()
         
         // THEN
-        XCTAssertEqual(sut.error, expectedError.errorDescription)
+        XCTAssertEqual(sut.error?.localizedDescription, expectedError.localizedDescription)
     }
     
     @MainActor func testLoadPhotosNamedSuccess() async {
@@ -98,6 +98,6 @@ class DiscoverPhotosViewModelTests: XCTestCase {
         await sut.loadPhotosNamed(query: expectedQuery)
         
         // THEN
-        XCTAssertEqual(sut.error, expectedError.errorDescription)
+        XCTAssertEqual(sut.error?.localizedDescription, expectedError.localizedDescription)
     }
 }

--- a/ImageQuestTests/Presentation/PhotoDetailViewModelTests.swift
+++ b/ImageQuestTests/Presentation/PhotoDetailViewModelTests.swift
@@ -43,6 +43,6 @@ class PhotoDetailViewModelTests: XCTestCase {
         await sut.loadDetailedPhoto(expectedDetailedPhoto.id)
         
         // THEN
-        XCTAssertEqual(sut.error, expectedError.errorDescription)
+        XCTAssertEqual(sut.error?.localizedDescription, expectedError.localizedDescription)
     }
 }


### PR DESCRIPTION
- Remove `errorDescription` from `NetworkError` in the Network Layer
- Create `NetworkAlert` as a `NetworkError` extension conforming to the new `AppAlert` protocol
- Create a custom alert `errorAlert` to improve alert management in the views
- Simplify error handling in view models
- Replace `errorDescription` with `localizedError` in tests
- Use `guard` instead of forced unwrap in `EndpointProtocol` extension
- Refactor `PhotoInfoSheet` by removing unnecessary `NavigationStack`
- Remove unnecessary code